### PR TITLE
Use bindgen 0.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ local-kcapi = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [build-dependencies]
-bindgen = "0.53"
+bindgen = "0.55"
 autotools = "0.2"
 fs_extra = "1.2.0"
 


### PR DESCRIPTION
This patch increases the version of bindgen used to 0.55. That version of bindgen is the earliest version that [starts using clang-sys 1.0][0] and since a lot of other projects indirectly depend on at least that version upgrading to at least 0.55 provides maximum compatibility with minimal amount of changes.

[0]: https://github.com/rust-lang/rust-bindgen/blob/main/CHANGELOG.md#0550

Note that I could increase bindgen version to higher numbers (recent is 0.66, 0.55 is 3 years old) but it's not strictly necessary in my work.